### PR TITLE
fix: db_init.sqlでカラムが重複している問題

### DIFF
--- a/docker/mysql/db_init.sql
+++ b/docker/mysql/db_init.sql
@@ -7,7 +7,6 @@ CREATE TABLE `exam` (
   `description` text COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `tag`         text COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `list` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL CHECK (json_valid(`list`)),
-  `tag`         text COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `deleted`     boolean NOT NULL DEFAULT false,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## Context
db_init.sqlのカラム重複が原因で、初回起動時のテーブル作成に失敗する
## Summary
重複していた行を削除