### PR TITLE
fix: ゴミ箱内のカテゴリもカウントしてしまっている問題

### DIFF
--- a/front/src/components/pages/list/list.tsx
+++ b/front/src/components/pages/list/list.tsx
@@ -174,7 +174,7 @@ export default function list(): React.ReactElement {
       {isLoading ? (
         <Loading />
       ) : (
-        <IndexedContainer len={list.length} width='300px'>
+        <IndexedContainer len={list.filter(e => e.deleted === Number(show_only_trash)).length} width='300px'>
           {CardList()}
         </IndexedContainer>
       )}


### PR DESCRIPTION
## Context
![image](https://github.com/watasuke102/TAGether/assets/73163994/ae5a89b1-631c-4da2-80fc-fc44645aeab1)
表示されているカテゴリ数とページ数が合わない
## Summary
ページ数を計算するとき、ゴミ箱内にあるかどうかを考慮してカテゴリ数をカウントするように変更